### PR TITLE
Add keygen, signing, and verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +158,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camino"
@@ -238,10 +259,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -269,16 +305,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -309,6 +448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filepack"
 version = "0.0.3"
 dependencies = [
@@ -318,10 +463,14 @@ dependencies = [
  "camino",
  "clap",
  "clap_mangen",
+ "dirs",
+ "ed25519-dalek",
+ "hex",
  "indicatif",
  "lexiclean",
  "owo-colors",
  "predicates",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -337,6 +486,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -374,6 +544,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ignore"
@@ -454,6 +630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,16 +694,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -568,6 +779,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +816,17 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -613,6 +865,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +900,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -686,10 +953,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "snafu"
@@ -713,10 +1000,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -747,6 +1050,32 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -780,6 +1109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +1134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,11 +1150,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -822,7 +1172,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -831,15 +1196,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -849,9 +1220,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -867,9 +1250,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -879,12 +1274,51 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,13 @@ blake3 = { version = "1.5.4", features = ["mmap", "rayon", "serde"] }
 camino = { version = "1.1.9", features = ["serde1"] }
 clap = { version = "4.5.16", features = ["derive"] }
 clap_mangen = "0.2.23"
+dirs = "5.0.1"
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+hex = "0.4.3"
 indicatif = "0.17.8"
 lexiclean = "0.0.1"
 owo-colors = "4"
+rand = "0.8.5"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 serde_yaml = "0.9.34"

--- a/justfile
+++ b/justfile
@@ -26,6 +26,9 @@ update-changelog:
 update-contributors:
   cargo run --release --package update-contributors
 
+doc:
+  cargo doc --all --open
+
 publish:
   #!/usr/bin/env bash
   set -euxo pipefail

--- a/src/display_secret.rs
+++ b/src/display_secret.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub(crate) struct DisplaySecret(pub(crate) PrivateKey);
+
+impl Display for DisplaySecret {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "{}", hex::encode(self.0.as_bytes()))
+  }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use super::*;
 pub(crate) enum Error {
   #[snafu(display("failed to get current directory"))]
   CurrentDir { source: io::Error },
+  #[snafu(display("failed to get local data directory"))]
+  DataLocalDir { backtrace: Option<Backtrace> },
   #[snafu(display("failed to deserialize manifest at `{path}`"))]
   DeserializeManifest {
     backtrace: Option<Backtrace>,
@@ -61,6 +63,12 @@ pub(crate) enum Error {
     path: DisplayPath,
     source: io::Error,
   },
+  #[snafu(display("public key `{public_key}` doesn't match private key `{private_key}`"))]
+  KeyMismatch {
+    backtrace: Option<Backtrace>,
+    public_key: String,
+    private_key: String,
+  },
   #[snafu(display("{count} lint error{}", if *count == 1 { "" } else { "s" }))]
   Lint {
     backtrace: Option<Backtrace>,
@@ -75,6 +83,71 @@ pub(crate) enum Error {
   PathUnicode {
     backtrace: Option<Backtrace>,
     path: PathBuf,
+  },
+  #[snafu(display("private key already exists: `{}`", path.display()))]
+  PrivateKeyAlreadyExists {
+    backtrace: Option<Backtrace>,
+    path: PathBuf,
+  },
+  #[snafu(display("invalid private key `{path}`"))]
+  PrivateKeyLoad {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+    source: private_key::Error,
+  },
+  #[snafu(display("private key not found: `{path}`"))]
+  PrivateKeyNotFound {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+  },
+  #[snafu(display("public key already exists: `{}`", path.display()))]
+  PublicKeyAlreadyExists {
+    backtrace: Option<Backtrace>,
+    path: PathBuf,
+  },
+  #[snafu(display("invalid public key `{path}`"))]
+  PublicKeyLoad {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+    source: public_key::Error,
+  },
+  #[snafu(display("public key not found: `{path}`"))]
+  PublicKeyNotFound {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+  },
+  #[snafu(display("signature `{path}` already exists"))]
+  SignatureAlreadyExists {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+  },
+  #[snafu(display("invalid signature filename: `{path}`"))]
+  SignatureFilename {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+  },
+  #[snafu(display("invalid signature: `{path}`"))]
+  SignatureInvalid {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+    source: SignatureError,
+  },
+  #[snafu(display("malformed signature: `{path}`"))]
+  SignatureMalformed {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+    source: signature::Error,
+  },
+  #[snafu(display("no signature found for key {key}"))]
+  SignatureMissing {
+    backtrace: Option<Backtrace>,
+    key: PublicKey,
+  },
+  #[snafu(display("invalid signature public key: `{path}`"))]
+  SignaturePublicKey {
+    backtrace: Option<Backtrace>,
+    path: DisplayPath,
+    source: public_key::Error,
   },
   #[snafu(display("I/O error reading standard input"))]
   StandardInputIo {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -16,6 +16,12 @@ impl From<blake3::Hash> for Hash {
   }
 }
 
+impl From<Hash> for [u8; 32] {
+  fn from(hash: Hash) -> Self {
+    hash.0.into()
+  }
+}
+
 impl Serialize for Hash {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ use {
   walkdir::WalkDir,
 };
 
+#[cfg(test)]
+use assert_fs::TempDir;
+
 mod arguments;
 mod display_path;
 mod display_secret;

--- a/src/options.rs
+++ b/src/options.rs
@@ -2,6 +2,12 @@ use super::*;
 
 #[derive(Parser)]
 pub(crate) struct Options {
+  #[arg(
+    long,
+    help = "Store local data, including private keys, in <DATA_DIR>",
+    env = "FILEPACK_DATA_DIR"
+  )]
+  pub(crate) data_dir: Option<Utf8PathBuf>,
   #[arg(long, help = "Memory-map files for hashing")]
   pub(crate) mmap: bool,
   #[arg(long, help = "Memory-map and read files in parallel for hashing")]
@@ -24,5 +30,18 @@ impl Options {
       hash: hasher.finalize().into(),
       size: hasher.count(),
     })
+  }
+
+  pub(crate) fn keydir(&self) -> Result<Utf8PathBuf> {
+    let path = if let Some(path) = &self.data_dir {
+      path.into()
+    } else {
+      let path = dirs::data_local_dir().context(error::DataLocalDir)?;
+      Utf8Path::from_path(&path)
+        .context(error::PathUnicode { path: &path })?
+        .join("filepack")
+    };
+
+    Ok(path.join("keys"))
   }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,7 +32,7 @@ impl Options {
     })
   }
 
-  pub(crate) fn keydir(&self) -> Result<Utf8PathBuf> {
+  pub(crate) fn key_dir(&self) -> Result<Utf8PathBuf> {
     let path = if let Some(path) = &self.data_dir {
       path.into()
     } else {
@@ -43,5 +43,41 @@ impl Options {
     };
 
     Ok(path.join("keys"))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn key_dir_default() {
+    assert_eq!(
+      Options {
+        data_dir: None,
+        mmap: false,
+        parallel: false,
+      }
+      .key_dir()
+      .unwrap(),
+      dirs::data_local_dir()
+        .unwrap()
+        .join("filepack")
+        .join("keys"),
+    );
+  }
+
+  #[test]
+  fn key_dir_set() {
+    assert_eq!(
+      Options {
+        data_dir: Some("hello".into()),
+        mmap: false,
+        parallel: false,
+      }
+      .key_dir()
+      .unwrap(),
+      Utf8Path::new("hello").join("keys"),
+    );
   }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ pub(crate) struct Options {
     help = "Store local data, including private keys, in <DATA_DIR>",
     env = "FILEPACK_DATA_DIR"
   )]
-  pub(crate) data_dir: Option<Utf8PathBuf>,
+  data_dir: Option<Utf8PathBuf>,
   #[arg(long, help = "Memory-map files for hashing")]
   pub(crate) mmap: bool,
   #[arg(long, help = "Memory-map and read files in parallel for hashing")]

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -110,4 +110,30 @@ mod tests {
       .parse::<PrivateKey>()
       .unwrap_err();
   }
+
+  #[test]
+  fn whitespace_is_trimmed_when_loading_from_disk() {
+    let dir = TempDir::new().unwrap();
+
+    let path = Utf8PathBuf::from_path_buf(dir.join("key")).unwrap();
+
+    let key = "0e56ae8b43aa93fd4c179ceaff96f729522622d26b4b5357bc959e476e59e107"
+      .parse::<PrivateKey>()
+      .unwrap();
+
+    fs::write(&path, format!(" \t{}\n", key.display_secret())).unwrap();
+
+    assert_eq!(PrivateKey::load(&path).unwrap(), key);
+  }
+
+  #[test]
+  fn whitespace_is_not_trimmed_when_parsing_from_string() {
+    "0e56ae8b43aa93fd4c179ceaff96f729522622d26b4b5357bc959e476e59e107"
+      .parse::<PrivateKey>()
+      .unwrap();
+
+    " 0e56ae8b43aa93fd4c179ceaff96f729522622d26b4b5357bc959e476e59e107"
+      .parse::<PrivateKey>()
+      .unwrap_err();
+  }
 }

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -136,4 +136,20 @@ mod tests {
       .parse::<PrivateKey>()
       .unwrap_err();
   }
+
+  #[test]
+  fn parse_hex_error() {
+    assert_eq!(
+      "xyz".parse::<PrivateKey>().unwrap_err().to_string(),
+      "invalid hex"
+    );
+  }
+
+  #[test]
+  fn parse_length_error() {
+    assert_eq!(
+      "0123".parse::<PrivateKey>().unwrap_err().to_string(),
+      "invalid length 2"
+    );
+  }
 }

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(Error)))]
+pub(crate) enum Error {
+  #[snafu(display("invalid hex"))]
+  Hex { source: hex::FromHexError },
+  #[snafu(display("invalid length {length}"))]
+  Length { length: usize },
+  #[snafu(display("weak key"))]
+  Weak,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PrivateKey(ed25519_dalek::SigningKey);
+
+impl PrivateKey {
+  const LEN: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+
+  pub(crate) fn as_bytes(&self) -> [u8; Self::LEN] {
+    self.0.to_bytes()
+  }
+
+  pub(crate) fn display_secret(&self) -> DisplaySecret {
+    DisplaySecret(self.clone())
+  }
+
+  pub(crate) fn generate() -> Self {
+    let inner = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+    let verifying_key = inner.verifying_key();
+    assert!(!verifying_key.is_weak());
+    Self(inner)
+  }
+
+  pub(crate) fn inner(&self) -> &ed25519_dalek::SigningKey {
+    &self.0
+  }
+
+  pub(crate) fn load(path: &Utf8Path) -> Result<Self> {
+    let private_key = match fs::read_to_string(path) {
+      Err(err) if err.kind() == io::ErrorKind::NotFound => {
+        return Err(error::PrivateKeyNotFound { path }.build())
+      }
+      result => result.context(error::Io { path })?,
+    };
+
+    let private_key = private_key
+      .trim()
+      .parse::<Self>()
+      .context(error::PrivateKeyLoad { path })?;
+
+    Ok(private_key)
+  }
+
+  pub(crate) fn public_key(&self) -> PublicKey {
+    self.clone().into()
+  }
+
+  pub(crate) fn sign(&self, message: &[u8]) -> Signature {
+    use ed25519_dalek::Signer;
+    self.0.sign(message).into()
+  }
+}
+
+impl FromStr for PrivateKey {
+  type Err = Error;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    let bytes = hex::decode(s).context(HexError)?;
+
+    let secret: [u8; Self::LEN] = bytes.as_slice().try_into().ok().context(LengthError {
+      length: bytes.len(),
+    })?;
+
+    let inner = ed25519_dalek::SigningKey::from_bytes(&secret);
+
+    ensure! {
+      !inner.verifying_key().is_weak(),
+      WeakError,
+    }
+
+    Ok(Self(inner))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse() {
+    let key = PrivateKey::generate();
+    assert_eq!(
+      key
+        .display_secret()
+        .to_string()
+        .parse::<PrivateKey>()
+        .unwrap(),
+      key
+    );
+  }
+
+  #[test]
+  fn must_have_leading_zeros() {
+    "0e56ae8b43aa93fd4c179ceaff96f729522622d26b4b5357bc959e476e59e107"
+      .parse::<PrivateKey>()
+      .unwrap();
+
+    "e56ae8b43aa93fd4c179ceaff96f729522622d26b4b5357bc959e476e59e107"
+      .parse::<PrivateKey>()
+      .unwrap_err();
+  }
+}

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -5,7 +5,7 @@ use super::*;
 pub(crate) enum Error {
   #[snafu(display("invalid hex"))]
   Hex { source: hex::FromHexError },
-  #[snafu(display("invalid length {length}"))]
+  #[snafu(display("invalid byte length {length}"))]
   Length { length: usize },
   #[snafu(display("weak key"))]
   Weak,
@@ -149,7 +149,7 @@ mod tests {
   fn parse_length_error() {
     assert_eq!(
       "0123".parse::<PrivateKey>().unwrap_err().to_string(),
-      "invalid length 2"
+      "invalid byte length 2"
     );
   }
 }

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -103,6 +103,12 @@ mod tests {
   use super::*;
 
   #[test]
+  fn parse() {
+    let key = PrivateKey::generate().public_key();
+    assert_eq!(key.to_string().parse::<PublicKey>().unwrap(), key);
+  }
+
+  #[test]
   fn must_have_leading_zeros() {
     "0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3"
       .parse::<PublicKey>()

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -154,4 +154,15 @@ mod tests {
       "invalid byte length 2: `0123`"
     );
   }
+
+  #[test]
+  fn weak_public_keys_are_forbidden() {
+    assert!(matches!(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+          .parse::<PublicKey>()
+          .unwrap_err(),
+        Error::Weak { key }
+          if key == "0000000000000000000000000000000000000000000000000000000000000000",
+    ));
+  }
 }

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(Error)))]
+pub(crate) enum Error {
+  #[snafu(display("invalid public key hex: `{key}`"))]
+  Hex {
+    key: String,
+    source: hex::FromHexError,
+  },
+  #[snafu(display("invalid public key: `{key}`"))]
+  Key { key: String, source: SignatureError },
+  #[snafu(display("invalid public key length {length}: `{key}`"))]
+  Length {
+    key: String,
+    length: usize,
+    source: TryFromSliceError,
+  },
+  #[snafu(display("weak public key: `{key}`"))]
+  Weak { key: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PublicKey(ed25519_dalek::VerifyingKey);
+
+impl PublicKey {
+  const LEN: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+
+  pub(crate) fn load(path: &Utf8Path) -> Result<Self> {
+    let public_key = match fs::read_to_string(path) {
+      Err(err) if err.kind() == io::ErrorKind::NotFound => {
+        return Err(error::PublicKeyNotFound { path }.build())
+      }
+      result => result.context(error::Io { path })?,
+    };
+
+    let public_key = public_key
+      .trim()
+      .parse::<Self>()
+      .context(error::PublicKeyLoad { path })?;
+
+    Ok(public_key)
+  }
+
+  pub(crate) fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+    self
+      .0
+      .verify_strict(message, signature.as_ref())
+      .map_err(SignatureError)
+  }
+}
+
+impl From<PrivateKey> for PublicKey {
+  fn from(private_key: PrivateKey) -> Self {
+    Self(private_key.inner().verifying_key())
+  }
+}
+
+impl FromStr for PublicKey {
+  type Err = Error;
+
+  fn from_str(key: &str) -> Result<Self, Self::Err> {
+    let bytes = hex::decode(key).context(HexError { key })?;
+
+    let array: [u8; Self::LEN] = bytes.as_slice().try_into().context(LengthError {
+      key,
+      length: bytes.len(),
+    })?;
+
+    let inner = ed25519_dalek::VerifyingKey::from_bytes(&array)
+      .map_err(SignatureError)
+      .context(KeyError { key })?;
+
+    ensure! {
+      !inner.is_weak(),
+      WeakError { key },
+    }
+
+    Ok(Self(inner))
+  }
+}
+
+impl Display for PublicKey {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "{}", hex::encode(self.0.to_bytes()))
+  }
+}
+
+impl Ord for PublicKey {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.0.as_bytes().cmp(other.0.as_bytes())
+  }
+}
+
+impl PartialOrd for PublicKey {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn must_have_leading_zeros() {
+    "0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3"
+      .parse::<PublicKey>()
+      .unwrap();
+
+    "f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3"
+      .parse::<PublicKey>()
+      .unwrap_err();
+  }
+}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -16,6 +16,7 @@ pub(crate) enum Error {
   },
 }
 
+#[derive(PartialEq)]
 pub(crate) struct Signature(ed25519_dalek::Signature);
 
 impl Signature {
@@ -73,6 +74,15 @@ impl FromStr for Signature {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn parse() {
+    let signature = PrivateKey::generate().sign(b"hello");
+    assert_eq!(
+      signature.to_string().parse::<Signature>().unwrap(),
+      signature
+    );
+  }
 
   #[test]
   fn display_is_lowercase_hex() {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(Error)))]
+pub(crate) enum Error {
+  #[snafu(display("invalid public key hex: `{key}`"))]
+  Hex {
+    key: String,
+    source: hex::FromHexError,
+  },
+  #[snafu(display("invalid public key length {length}: `{key}`"))]
+  Length {
+    key: String,
+    length: usize,
+    source: TryFromSliceError,
+  },
+}
+
+pub(crate) struct Signature(ed25519_dalek::Signature);
+
+impl Signature {
+  const LEN: usize = ed25519_dalek::Signature::BYTE_SIZE;
+}
+
+impl AsRef<ed25519_dalek::Signature> for Signature {
+  fn as_ref(&self) -> &ed25519_dalek::Signature {
+    &self.0
+  }
+}
+
+impl From<ed25519_dalek::Signature> for Signature {
+  fn from(inner: ed25519_dalek::Signature) -> Self {
+    Self(inner)
+  }
+}
+
+impl From<Signature> for ed25519_dalek::Signature {
+  fn from(signature: Signature) -> Self {
+    signature.0
+  }
+}
+
+impl Display for Signature {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    for byte in self.0.to_bytes() {
+      write!(f, "{byte:02x}")?;
+    }
+    Ok(())
+  }
+}
+
+impl fmt::Debug for Signature {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    <dyn std::fmt::Debug>::fmt(&self.0, f)
+  }
+}
+
+impl FromStr for Signature {
+  type Err = Error;
+
+  fn from_str(key: &str) -> Result<Self, Self::Err> {
+    let bytes = hex::decode(key).context(HexError { key })?;
+
+    let array: [u8; Self::LEN] = bytes.as_slice().try_into().context(LengthError {
+      key,
+      length: bytes.len(),
+    })?;
+
+    Ok(Self(ed25519_dalek::Signature::from_bytes(&array)))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn display_is_lowercase_hex() {
+    let s = "0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3\
+     0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3";
+
+    assert_eq!(s.parse::<Signature>().unwrap().to_string(), s);
+  }
+
+  #[test]
+  fn must_have_leading_zeros() {
+    "0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3\
+     0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3"
+      .parse::<Signature>()
+      .unwrap();
+
+    "f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3\
+     0f6d444f09eb336d3cc94d66cc541fea0b70b36be291eb3ecf5b49113f34c8d3"
+      .parse::<Signature>()
+      .unwrap_err();
+  }
+}

--- a/src/signature_error.rs
+++ b/src/signature_error.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+pub(crate) struct SignatureError(pub(crate) ed25519_dalek::SignatureError);
+
+impl Display for SignatureError {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    self.0.fmt(f)
+  }
+}
+
+impl fmt::Debug for SignatureError {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    <dyn std::fmt::Debug>::fmt(&self.0, f)
+  }
+}
+
+impl std::error::Error for SignatureError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    self.0.source()?.source()
+  }
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -28,10 +28,10 @@ pub(crate) enum Subcommand {
   Create(create::Create),
   #[command(about = "hash single file")]
   Hash(hash::Hash),
-  #[command(about = "Generate new key pair")]
-  Keygen,
   #[command(about = "Print master key")]
   Key,
+  #[command(about = "Generate new key pair")]
+  Keygen,
   #[command(about = "print man page")]
   Man,
   #[command(about = "verify directory against manifest")]
@@ -43,8 +43,8 @@ impl Subcommand {
     match self {
       Self::Create(create) => create.run(options),
       Self::Hash(hash) => hash.run(options),
-      Self::Keygen => keygen::run(options),
       Self::Key => key::run(options),
+      Self::Keygen => keygen::run(options),
       Self::Man => man::run(),
       Self::Verify(verify) => verify.run(options),
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -30,7 +30,7 @@ pub(crate) enum Subcommand {
   Hash(hash::Hash),
   #[command(about = "Print master key")]
   Key,
-  #[command(about = "Generate new key pair")]
+  #[command(about = "Generate new master key")]
   Keygen,
   #[command(about = "print man page")]
   Man,

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -8,6 +8,8 @@ use {
 
 mod create;
 mod hash;
+mod key;
+mod keygen;
 mod man;
 mod verify;
 
@@ -26,6 +28,10 @@ pub(crate) enum Subcommand {
   Create(create::Create),
   #[command(about = "hash single file")]
   Hash(hash::Hash),
+  #[command(about = "Generate new key pair")]
+  Keygen,
+  #[command(about = "Print master key")]
+  Key,
   #[command(about = "print man page")]
   Man,
   #[command(about = "verify directory against manifest")]
@@ -37,6 +43,8 @@ impl Subcommand {
     match self {
       Self::Create(create) => create.run(options),
       Self::Hash(hash) => hash.run(options),
+      Self::Keygen => keygen::run(options),
+      Self::Key => key::run(options),
       Self::Man => man::run(),
       Self::Verify(verify) => verify.run(options),
     }

--- a/src/subcommand/create.rs
+++ b/src/subcommand/create.rs
@@ -180,7 +180,7 @@ impl Create {
     fs::write(&manifest, &json).context(error::Io { path: manifest })?;
 
     if self.sign {
-      let private_key_path = options.keydir()?.join(MASTER_PRIVATE_KEY);
+      let private_key_path = options.key_dir()?.join(MASTER_PRIVATE_KEY);
 
       let private_key = PrivateKey::load(&private_key_path)?;
 

--- a/src/subcommand/key.rs
+++ b/src/subcommand/key.rs
@@ -1,11 +1,11 @@
 use super::*;
 
 pub(crate) fn run(options: Options) -> Result {
-  let keys = options.keydir()?;
+  let key_dir = options.key_dir()?;
 
-  let public_key = PublicKey::load(&keys.join(MASTER_PUBLIC_KEY))?;
+  let public_key = PublicKey::load(&key_dir.join(MASTER_PUBLIC_KEY))?;
 
-  let private_key = PrivateKey::load(&keys.join(MASTER_PRIVATE_KEY))?;
+  let private_key = PrivateKey::load(&key_dir.join(MASTER_PRIVATE_KEY))?;
 
   ensure! {
     private_key.public_key() == public_key,

--- a/src/subcommand/key.rs
+++ b/src/subcommand/key.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+pub(crate) fn run(options: Options) -> Result {
+  let keys = options.keydir()?;
+
+  let public_key = PublicKey::load(&keys.join(MASTER_PUBLIC_KEY))?;
+
+  let private_key = PrivateKey::load(&keys.join(MASTER_PRIVATE_KEY))?;
+
+  ensure! {
+    private_key.public_key() == public_key,
+    error::KeyMismatch {
+      public_key: MASTER_PUBLIC_KEY,
+      private_key: MASTER_PRIVATE_KEY,
+    },
+  }
+
+  println!("{public_key}");
+
+  Ok(())
+}

--- a/src/subcommand/keygen.rs
+++ b/src/subcommand/keygen.rs
@@ -1,18 +1,18 @@
 use super::*;
 
 pub(crate) fn run(option: Options) -> Result {
-  let keys = option.keydir()?;
+  let key_dir = option.key_dir()?;
 
-  fs::create_dir_all(&keys).context(error::Io { path: &keys })?;
+  fs::create_dir_all(&key_dir).context(error::Io { path: &key_dir })?;
 
-  let private_path = keys.join(MASTER_PRIVATE_KEY);
+  let private_path = key_dir.join(MASTER_PRIVATE_KEY);
 
   ensure! {
     !private_path.try_exists().context(error::Io { path: &private_path})?,
     error::PrivateKeyAlreadyExists { path: private_path },
   }
 
-  let public_path = keys.join(MASTER_PUBLIC_KEY);
+  let public_path = key_dir.join(MASTER_PUBLIC_KEY);
 
   ensure! {
     !public_path.try_exists().context(error::Io { path: &public_path})?,

--- a/src/subcommand/keygen.rs
+++ b/src/subcommand/keygen.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub(crate) fn run(option: Options) -> Result {
+  let keys = option.keydir()?;
+
+  fs::create_dir_all(&keys).context(error::Io { path: &keys })?;
+
+  let private_path = keys.join(MASTER_PRIVATE_KEY);
+
+  ensure! {
+    !private_path.try_exists().context(error::Io { path: &private_path})?,
+    error::PrivateKeyAlreadyExists { path: private_path },
+  }
+
+  let public_path = keys.join(MASTER_PUBLIC_KEY);
+
+  ensure! {
+    !public_path.try_exists().context(error::Io { path: &public_path})?,
+    error::PublicKeyAlreadyExists { path: public_path },
+  }
+
+  let private_key = PrivateKey::generate();
+
+  fs::write(&private_path, format!("{}\n", private_key.display_secret()))
+    .context(error::Io { path: private_path })?;
+
+  let public_key = private_key.public_key();
+
+  fs::write(&public_path, format!("{public_key}\n")).context(error::Io { path: public_path })?;
+
+  Ok(())
+}

--- a/src/subcommand/verify.rs
+++ b/src/subcommand/verify.rs
@@ -3,6 +3,12 @@ use super::*;
 #[derive(Parser)]
 pub(crate) struct Verify {
   #[arg(
+    help = "Verify that manifest has been signed by <PUBKEY>",
+    long,
+    value_name = "PUBKEY"
+  )]
+  key: Option<PublicKey>,
+  #[arg(
     help = "Read manifest from <MANIFEST>, defaults to `<ROOT>/filepack.json`",
     long
   )]
@@ -106,6 +112,8 @@ mismatched file: `{path}`
 
     let mut dirs = Vec::new();
 
+    let mut signatures = BTreeSet::new();
+
     for entry in WalkDir::new(&root) {
       let entry = entry?;
 
@@ -134,11 +142,49 @@ mismatched file: `{path}`
 
       let path = path.strip_prefix(&root).unwrap();
 
+      if path == SIGNATURES {
+        continue;
+      }
+
+      if path.starts_with(SIGNATURES) {
+        ensure! {
+          path.extension() == Some("signature"),
+          error::SignatureFilename { path },
+        }
+
+        let pubkey = path
+          .file_stem()
+          .context(error::SignatureFilename { path })?
+          .parse::<PublicKey>()
+          .context(error::SignaturePublicKey { path })?;
+
+        let signature = fs::read_to_string(entry.path()).context(error::Io { path })?;
+
+        let signature = signature
+          .parse::<Signature>()
+          .context(error::SignatureMalformed { path })?;
+
+        pubkey
+          .verify(json.as_bytes(), &signature)
+          .context(error::SignatureInvalid { path })?;
+
+        signatures.insert(pubkey);
+
+        continue;
+      }
+
       let path = RelativePath::try_from(path).context(error::Path { path })?;
 
       ensure! {
         manifest.files.contains_key(&path),
         error::ExtraneousFile { path },
+      }
+    }
+
+    if let Some(key) = self.key {
+      ensure! {
+        signatures.contains(&key),
+        error::SignatureMissing { key },
       }
     }
 

--- a/src/subcommand/verify.rs
+++ b/src/subcommand/verify.rs
@@ -3,9 +3,9 @@ use super::*;
 #[derive(Parser)]
 pub(crate) struct Verify {
   #[arg(
-    help = "Verify that manifest has been signed by <PUBKEY>",
+    help = "Verify that manifest has been signed by <KEY>",
     long,
-    value_name = "PUBKEY"
+    value_name = "KEY"
   )]
   key: Option<PublicKey>,
   #[arg(

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -543,7 +543,7 @@ fn private_key_load_error_message() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(
-      "error: invalid private key `.*master.private`.*invalid length 0.*",
+      "error: invalid private key `.*master.private`.*invalid byte length 0.*",
     ))
     .failure();
 }

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -509,3 +509,125 @@ fn metadata_template_should_not_be_included_in_package() {
     .stderr("error: metadata template `metadata.yaml` should not be included in package\n")
     .failure();
 }
+
+#[test]
+fn sign_fails_if_master_key_not_available() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("foo/bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["create", "--sign", "foo"])
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: private key not found: `.*master.private`\n",
+    ))
+    .failure();
+}
+
+#[test]
+fn private_key_load_error_message() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("foo/bar").touch().unwrap();
+
+  dir.child("keys/master.private").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["create", "--sign", "foo"])
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: invalid private key `.*master.private`.*invalid length 0.*",
+    ))
+    .failure();
+}
+
+#[test]
+fn sign_creates_valid_signature() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("foo/bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["create", "--sign", "foo"])
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let public_key = fs::read_to_string(dir.child("keys/master.public"))
+    .unwrap()
+    .trim()
+    .to_owned();
+
+  let signature =
+    fs::read_to_string(dir.child(format!("foo/signatures/{public_key}.signature"))).unwrap();
+
+  let signature = signature.parse::<ed25519_dalek::Signature>().unwrap();
+
+  let public_key =
+    ed25519_dalek::VerifyingKey::from_bytes(&hex::decode(public_key).unwrap().try_into().unwrap())
+      .unwrap();
+
+  let manifest = fs::read_to_string(dir.child("foo/filepack.json")).unwrap();
+
+  public_key
+    .verify_strict(manifest.as_bytes(), &signature)
+    .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["verify", "foo"])
+    .current_dir(&dir)
+    .assert()
+    .success();
+}
+
+#[test]
+fn existing_signature_will_not_be_overwritten() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let public_key = fs::read_to_string(dir.child("keys/master.public"))
+    .unwrap()
+    .trim()
+    .to_owned();
+
+  dir
+    .child(format!("foo/signatures/{public_key}.signature"))
+    .touch()
+    .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["create", "--sign", "foo"])
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(format!(
+      "error: signature `foo/signatures/{public_key}.signature` already exists\n"
+    ))
+    .failure();
+}

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -627,7 +627,7 @@ fn existing_signature_will_not_be_overwritten() {
     .current_dir(&dir)
     .assert()
     .stderr(format!(
-      "error: signature `foo/signatures/{public_key}.signature` already exists\n"
+      "error: signature `foo{SEPARATOR}signatures{SEPARATOR}{public_key}.signature` already exists\n"
     ))
     .failure();
 }

--- a/tests/key.rs
+++ b/tests/key.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+#[test]
+fn prints_pubkey() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let output = Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("key")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success()
+    .stdout(is_match("[0-9a-f]{64}\n"))
+    .get_output()
+    .clone();
+
+  let public_key = fs::read_to_string(dir.child("keys/master.public")).unwrap();
+
+  assert_eq!(str::from_utf8(&output.stdout).unwrap(), public_key);
+}
+
+#[test]
+fn missing_public_key_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  fs::remove_file(dir.child("keys/master.public")).unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("key")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match("error: public key not found: `.*master.public`\n"))
+    .failure();
+}
+
+#[test]
+fn missing_private_key_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  fs::remove_file(dir.child("keys/master.private")).unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("key")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: private key not found: `.*master.private`\n",
+    ))
+    .failure();
+}
+
+#[test]
+fn mismatched_key_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path().join("foo"))
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("keygen")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  fs::rename(
+    dir.path().join("foo/keys/master.private"),
+    dir.path().join("keys/master.private"),
+  )
+  .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("key")
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: public key `master.public` doesn't match private key `master.private`\n",
+    ))
+    .failure();
+}

--- a/tests/keygen.rs
+++ b/tests/keygen.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[test]
+fn keygen_generates_master_key_by_default() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .arg("keygen")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let public = dir.child("keys/master.public");
+
+  public.assert(is_match("[0-9a-f]{64}\n"));
+
+  let private = dir.child("keys/master.private");
+
+  private.assert(is_match("[0-9a-f]{64}\n"));
+
+  let public = ed25519_dalek::VerifyingKey::from_bytes(
+    &hex::decode(fs::read_to_string(public).unwrap().trim())
+      .unwrap()
+      .try_into()
+      .unwrap(),
+  )
+  .unwrap();
+
+  let private = ed25519_dalek::SigningKey::from_bytes(
+    &hex::decode(fs::read_to_string(private).unwrap().trim())
+      .unwrap()
+      .try_into()
+      .unwrap(),
+  );
+
+  assert!(!public.is_weak());
+
+  assert_eq!(private.verifying_key(), public);
+}
+
+#[test]
+fn error_if_master_public_key_already_exists() {
+  let dir = TempDir::new().unwrap();
+
+  let keys = dir.child("keys");
+
+  fs::create_dir_all(&keys).unwrap();
+
+  fs::write(keys.child("master.public"), "foo").unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .arg("keygen")
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: public key already exists: `.*master.public`\n",
+    ))
+    .failure();
+}
+
+#[test]
+fn error_if_master_private_key_already_exists() {
+  let dir = TempDir::new().unwrap();
+
+  let keys = dir.child("keys");
+
+  fs::create_dir_all(&keys).unwrap();
+
+  fs::write(keys.child("master.private"), "foo").unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .arg("keygen")
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: private key already exists: `.*master.private`\n",
+    ))
+    .failure();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,6 +6,7 @@ use {
     TempDir,
   },
   predicates::str::RegexPredicate,
+  std::{fs, str},
 };
 
 const SEPARATOR: char = std::path::MAIN_SEPARATOR;
@@ -14,11 +15,13 @@ fn is_match<S>(pattern: S) -> RegexPredicate
 where
   S: AsRef<str>,
 {
-  predicates::prelude::predicate::str::is_match(pattern).unwrap()
+  predicates::prelude::predicate::str::is_match(format!("^(?s){}$", pattern.as_ref())).unwrap()
 }
 
 mod create;
 mod hash;
+mod key;
+mod keygen;
 mod man;
 mod misc;
 mod verify;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,7 +9,8 @@ use {
   std::{fs, str},
 };
 
-const SEPARATOR: char = std::path::MAIN_SEPARATOR;
+const SEPARATOR: char = if cfg!(windows) { '\\' } else { '/' };
+const SEPARATOR_RE: &str = if cfg!(windows) { r"\\" } else { "/" };
 
 fn is_match<S>(pattern: S) -> RegexPredicate
 where

--- a/tests/man.rs
+++ b/tests/man.rs
@@ -6,6 +6,6 @@ fn man() {
     .unwrap()
     .arg("man")
     .assert()
-    .stdout(is_match(r#"\.TH filepack 1  "filepack \d+\.\d+\.\d+""#))
+    .stdout(is_match(r#".*\.TH filepack 1  "filepack \d+\.\d+\.\d+".*"#))
     .success();
 }

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -593,7 +593,7 @@ fn weak_signature_public_key() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(
-      "error: invalid signature public key: `signatures/0{64}.signature`\n.*weak public key.*",
+      "error: invalid signature public key: `signatures/0{64}.signature`\n.*weak key.*",
     ))
     .failure();
 }

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -570,7 +570,7 @@ fn invalid_signature_public_key() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(format!(
-      "error: invalid signature public key: `signatures{SEPARATOR}hello.signature`\n.*"
+      "error: invalid signature public key: `signatures{SEPARATOR_RE}hello.signature`\n.*"
     )))
     .failure();
 }
@@ -599,7 +599,7 @@ fn weak_signature_public_key() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(format!(
-      "error: invalid signature public key: `signatures{SEPARATOR}0{{64}}.signature`\n.*weak key.*"
+      "error: invalid signature public key: `signatures{SEPARATOR_RE}0{{64}}.signature`\n.*weak key.*"
     )))
     .failure();
 }
@@ -654,7 +654,7 @@ fn malformed_signature_error() {
     .assert()
     .stderr(is_match(
       format!("error: malformed signature: \
-      `signatures{SEPARATOR}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*",
+      `signatures{SEPARATOR_RE}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*",
     )))
     .failure();
 }
@@ -699,7 +699,7 @@ fn valid_signature_for_wrong_pubkey_error() {
     .stderr(is_match(
         format!(
       "error: invalid signature: \
-      `signatures{SEPARATOR}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*Verification equation was not satisfied.*",
+      `signatures{SEPARATOR_RE}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*Verification equation was not satisfied.*",
         )
     ))
     .failure();

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -470,3 +470,229 @@ fn manifest_metadata_allows_unknown_keys() {
     .assert()
     .success();
 }
+
+#[test]
+fn missing_signature_file_extension() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("signatures/foo").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr("error: invalid signature filename: `signatures/foo`\n")
+    .failure();
+}
+
+#[test]
+fn invalid_signature_file_extension() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("signatures/foo.baz").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr("error: invalid signature filename: `signatures/foo.baz`\n")
+    .failure();
+}
+
+#[test]
+fn missing_signature_file_stem() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("signatures/.signature").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr("error: invalid signature filename: `signatures/.signature`\n")
+    .failure();
+}
+
+#[test]
+fn invalid_signature_public_key() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("signatures/hello.signature").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: invalid signature public key: `signatures/hello.signature`\n.*",
+    ))
+    .failure();
+}
+
+#[test]
+fn weak_signature_public_key() {
+  let dir = TempDir::new().unwrap();
+
+  dir.child("bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir
+    .child("signatures/0000000000000000000000000000000000000000000000000000000000000000.signature")
+    .touch()
+    .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: invalid signature public key: `signatures/0{64}.signature`\n.*weak public key.*",
+    ))
+    .failure();
+}
+
+#[test]
+fn missing_signature_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args([
+      "verify",
+      "--key",
+      "7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b",
+    ])
+    .current_dir(&dir)
+    .assert()
+    .stderr(
+      "error: no signature found for key \
+      7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b\n",
+    )
+    .failure();
+}
+
+#[test]
+fn malformed_signature_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("create")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir
+    .child("signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature")
+    .write_str("7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b")
+    .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .arg("verify")
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: malformed signature: \
+      `signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*",
+    ))
+    .failure();
+}
+
+#[test]
+fn valid_signature_for_wrong_pubkey_error() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .arg("keygen")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("foo/bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .args(["create", "--sign", "foo"])
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let public_key = fs::read_to_string(dir.child("keys/master.public")).unwrap();
+
+  fs::rename(
+    dir.child(format!("foo/signatures/{}.signature", public_key.trim())),
+    dir.child(
+      "foo/signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature",
+    ),
+  )
+  .unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["verify", "foo"])
+    .current_dir(&dir)
+    .assert()
+    .stderr(is_match(
+      "error: invalid signature: \
+      `signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*Verification equation was not satisfied.*",
+    ))
+    .failure();
+}

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -696,3 +696,35 @@ fn valid_signature_for_wrong_pubkey_error() {
     ))
     .failure();
 }
+
+#[test]
+fn signature_verification_success() {
+  let dir = TempDir::new().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .arg("keygen")
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  dir.child("foo/bar").touch().unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .env("FILEPACK_DATA_DIR", dir.path())
+    .args(["create", "--sign", "foo"])
+    .current_dir(&dir)
+    .assert()
+    .success();
+
+  let public_key = fs::read_to_string(dir.child("keys/master.public")).unwrap();
+
+  Command::cargo_bin("filepack")
+    .unwrap()
+    .args(["verify", "foo", "--key", public_key.trim()])
+    .current_dir(&dir)
+    .assert()
+    .success();
+}

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -491,7 +491,9 @@ fn missing_signature_file_extension() {
     .arg("verify")
     .current_dir(&dir)
     .assert()
-    .stderr("error: invalid signature filename: `signatures/foo`\n")
+    .stderr(format!(
+      "error: invalid signature filename: `signatures{SEPARATOR}foo`\n"
+    ))
     .failure();
 }
 
@@ -515,7 +517,9 @@ fn invalid_signature_file_extension() {
     .arg("verify")
     .current_dir(&dir)
     .assert()
-    .stderr("error: invalid signature filename: `signatures/foo.baz`\n")
+    .stderr(format!(
+      "error: invalid signature filename: `signatures{SEPARATOR}foo.baz`\n"
+    ))
     .failure();
 }
 
@@ -539,7 +543,9 @@ fn missing_signature_file_stem() {
     .arg("verify")
     .current_dir(&dir)
     .assert()
-    .stderr("error: invalid signature filename: `signatures/.signature`\n")
+    .stderr(format!(
+      "error: invalid signature filename: `signatures{SEPARATOR}.signature`\n"
+    ))
     .failure();
 }
 
@@ -563,9 +569,9 @@ fn invalid_signature_public_key() {
     .arg("verify")
     .current_dir(&dir)
     .assert()
-    .stderr(is_match(
-      "error: invalid signature public key: `signatures/hello.signature`\n.*",
-    ))
+    .stderr(is_match(format!(
+      "error: invalid signature public key: `signatures{SEPARATOR}hello.signature`\n.*"
+    )))
     .failure();
 }
 
@@ -592,9 +598,9 @@ fn weak_signature_public_key() {
     .arg("verify")
     .current_dir(&dir)
     .assert()
-    .stderr(is_match(
-      "error: invalid signature public key: `signatures/0{64}.signature`\n.*weak key.*",
-    ))
+    .stderr(is_match(format!(
+      "error: invalid signature public key: `signatures{SEPARATOR}0{{64}}.signature`\n.*weak key.*"
+    )))
     .failure();
 }
 
@@ -647,9 +653,9 @@ fn malformed_signature_error() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(
-      "error: malformed signature: \
-      `signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*",
-    ))
+      format!("error: malformed signature: \
+      `signatures{SEPARATOR}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*",
+    )))
     .failure();
 }
 
@@ -691,8 +697,10 @@ fn valid_signature_for_wrong_pubkey_error() {
     .current_dir(&dir)
     .assert()
     .stderr(is_match(
+        format!(
       "error: invalid signature: \
-      `signatures/7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*Verification equation was not satisfied.*",
+      `signatures{SEPARATOR}7f1420cdc898f9370fd196b9e8e5606a7992fab5144fc1873d91b8c65ef5db6b.signature`\n.*Verification equation was not satisfied.*",
+        )
     ))
     .failure();
 }


### PR DESCRIPTION
I'm still not sure what the right implementation is. We could use PGP, ssh-keygen, or roll our own signing and verification.

PGP and ssh-keygen are widely available. PGP is already commonly used to sign open source releases. However, both are complicated, with poor APIs, support for lots of weird legacy crypto systems, and use formats which seem to me to be unnecessary and weird.

I would much prefer to use:

- Plain hex instead of base64
- Actual pubkeys instead of pubkey fingerprints
- JSON instead of ASCII armor
- The BLAKE3 hash function and a single curve like secp256k1 or ed25519, as opposed  to arbitrary pluggable hashes and crypto systems

Still very much unsure which path is right.