### PR TITLE
Use JSON to calculate root hash

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -13,14 +13,14 @@ impl Manifest {
   pub(crate) const FILENAME: &'static str = "filepack.json";
 
   pub(crate) fn root_hash(&self) -> Hash {
+    let canonical = Self {
+      files: self.files.clone(),
+      signatures: BTreeMap::new(),
+    };
+
     let mut hasher = blake3::Hasher::new();
 
-    for (path, entry) in &self.files {
-      hasher.update(&u64::try_from(path.len()).unwrap().to_le_bytes());
-      hasher.update(path.as_str().as_bytes());
-      hasher.update(&entry.size.to_le_bytes());
-      hasher.update(entry.hash.as_bytes());
-    }
+    serde_json::to_writer(&mut hasher, &canonical).unwrap();
 
     hasher.finalize().into()
   }

--- a/src/relative_path.rs
+++ b/src/relative_path.rs
@@ -20,14 +20,6 @@ impl RelativePath {
 
   const JUNK_NAMES: [&'static str; 2] = [".DS_Store", ".localized"];
 
-  pub(crate) fn as_str(&self) -> &str {
-    self.0.as_str()
-  }
-
-  pub(crate) fn len(&self) -> usize {
-    self.0.len()
-  }
-
   pub(crate) fn lint(&self) -> Option<Lint> {
     for component in Utf8Path::new(&self.0).components() {
       let Utf8Component::Normal(component) = component else {

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -586,14 +586,7 @@ fn sign_creates_valid_signature() {
     ed25519_dalek::VerifyingKey::from_bytes(&hex::decode(public_key).unwrap().try_into().unwrap())
       .unwrap();
 
-  let mut hasher = blake3::Hasher::new();
-
-  hasher.update(&3u64.to_le_bytes());
-  hasher.update("bar".as_bytes());
-  hasher.update(&0u64.to_le_bytes());
-  hasher.update(blake3::hash(&[]).as_bytes());
-
-  let root_hash = hasher.finalize();
+  let root_hash = blake3::hash(r#"{"files":{"bar":{"hash":"af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262","size":0}}}"#.as_bytes());
 
   public_key
     .verify_strict(root_hash.as_bytes(), &signature)

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -641,7 +641,7 @@ fn verify_hash() {
     .args([
       "verify",
       "--hash",
-      "409a47939fea6278f60d878fd85d57fe753fa7d87c0dba8e4e4a2b61c81077fb",
+      "74ddbe0dcf48c634aca1d90f37defd60b230fc52857ffa4b6c956583e8a4daaf",
     ])
     .current_dir(&dir)
     .assert()
@@ -660,7 +660,7 @@ fn verify_hash() {
       "\
 root hash mismatch: `.*filepack\\.json`
           expected: 0000000000000000000000000000000000000000000000000000000000000000
-            actual: 409a47939fea6278f60d878fd85d57fe753fa7d87c0dba8e4e4a2b61c81077fb
+            actual: 74ddbe0dcf48c634aca1d90f37defd60b230fc52857ffa4b6c956583e8a4daaf
 error: root hash mismatch\n",
     ))
     .failure();


### PR DESCRIPTION
Use JSON instead of an ad-hoc binary serialization format to calculate the root hash.

This will need to be revisited. We use `serde_json`, which does not guarantee canonical JSON output. However, for now, I think this is better than using something random.